### PR TITLE
Add BeginReparent/EndReparent support for visual-tree re-parenting (Avalonia 12)

### DIFF
--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalControl.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalControl.cs
@@ -175,6 +175,26 @@ namespace Iciclecreek.Terminal
         public void Kill() => _terminalView!.Kill();
 
         /// <summary>
+        /// Call before removing this control from one visual tree and adding it to another
+        /// (e.g. moving between windows). Prevents the PTY process from being killed
+        /// during the detach. Pair with <see cref="EndReparent"/> after re-attaching.
+        /// </summary>
+        public void BeginReparent() => _terminalView?.BeginReparent();
+
+        /// <summary>
+        /// Call after the control has been re-attached to a new visual tree to restore
+        /// normal cleanup behaviour.
+        /// </summary>
+        public void EndReparent() => _terminalView?.EndReparent();
+
+        /// <inheritdoc cref="TerminalView.ShowCaretOnClickProperty"/>
+        public bool ShowCaretOnClick
+        {
+            get => _terminalView?.ShowCaretOnClick ?? false;
+            set { if (_terminalView != null) _terminalView.ShowCaretOnClick = value; }
+        }
+
+        /// <summary>
         /// Gets the exit code of the launched process after it has terminated.
         /// </summary>
         public int ExitCode => _terminalView!.ExitCode;

--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -47,12 +47,19 @@ namespace Iciclecreek.Terminal
 
         // Selection state - tracks whether terminal is handling selection vs forwarding mouse to app
         private bool _isSelecting = false;
+        // When non-null, a single left-click has been pressed but the selection hasn't started yet.
+        // Selection start is deferred until pointer movement so that a plain click doesn't show a caret.
+        private (int Col, int Row)? _pendingSelectionStart = null;
 
         // IME (Input Method Editor) support
         private TerminalInputMethodClient? _inputMethodClient;
 
         // Unique identifier for this terminal instance (for debugging)
         private readonly Guid _instanceId = Guid.NewGuid();
+
+        // When true, OnDetachedFromLogicalTree skips CleanupProcess so the PTY
+        // survives a visual-tree re-parent (e.g. floating window pop-out/dock-back).
+        private bool _suppressCleanupOnDetach;
 
         private sealed record CachedTextRun(FormattedText Text, int StartX, int CellCount, IBrush Background);
 
@@ -162,6 +169,25 @@ namespace Iciclecreek.Terminal
             AvaloniaProperty.Register<TerminalView, int>(
                 nameof(CursorBlinkRate),
                 defaultValue: 530);
+
+        /// <summary>
+        /// When <see langword="false"/> (default), a plain single left-click does not
+        /// immediately show a selection highlight. The selection only starts once the
+        /// pointer moves, so casual clicks produce no visible caret artifact.
+        /// Set to <see langword="true"/> to restore the original behaviour where a
+        /// single-cell highlight appears on every click.
+        /// Double- and triple-click (word / line selection) are unaffected by this setting.
+        /// </summary>
+        public static readonly StyledProperty<bool> ShowCaretOnClickProperty =
+            AvaloniaProperty.Register<TerminalView, bool>(
+                nameof(ShowCaretOnClick),
+                defaultValue: false);
+
+        public bool ShowCaretOnClick
+        {
+            get => GetValue(ShowCaretOnClickProperty);
+            set => SetValue(ShowCaretOnClickProperty, value);
+        }
 
         public static readonly StyledProperty<XTerm.Options.TerminalOptions?> OptionsProperty =
             AvaloniaProperty.Register<TerminalControl, XTerm.Options.TerminalOptions?>(
@@ -777,7 +803,21 @@ namespace Iciclecreek.Terminal
         {
             _cursorBlinkTimer.Stop();
             _isSelecting = false;
+            _pendingSelectionStart = null;
         }
+
+        /// <summary>
+        /// Call before removing this view from one visual tree and adding it to another.
+        /// Prevents <see cref="OnDetachedFromLogicalTree"/> from killing the PTY process.
+        /// Must be paired with <see cref="EndReparent"/> once re-attached.
+        /// </summary>
+        public void BeginReparent() => _suppressCleanupOnDetach = true;
+
+        /// <summary>
+        /// Call after the view has been re-attached to a new visual tree to restore
+        /// normal cleanup behaviour and ensure render handlers are wired up.
+        /// </summary>
+        public void EndReparent() => _suppressCleanupOnDetach = false;
 
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
@@ -798,7 +838,52 @@ namespace Iciclecreek.Terminal
             _terminal.BellRang -= OnTerminalBellRang;
             _terminal.DirectoryChanged -= OnTerminalDirectoryChanged;
             _terminal.WindowInfoRequested -= OnTerminalWindowInfoRequested;
-            CleanupProcess();
+
+            if (!_suppressCleanupOnDetach)
+                CleanupProcess();
+        }
+
+        protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToLogicalTree(e);
+
+            // _terminal is null during initial attachment (OnInitialized hasn't fired yet).
+            // Only re-subscribe when re-parenting after a prior detach.
+            if (_terminal == null) return;
+
+            // Re-subscribe terminal events that were unsubscribed on detach.
+            // Use -= before += to avoid double-subscription.
+            _terminal.DataReceived -= OnTerminalDataReceived;
+            _terminal.BufferChanged -= OnTerminalBufferChanged;
+            _terminal.CursorStyleChanged -= OnTerminalCursorStyleChanged;
+            _terminal.TitleChanged -= OnTerminalTitleChanged;
+            _terminal.WindowMoved -= OnTerminalWindowMoved;
+            _terminal.WindowResized -= OnTerminalWindowResized;
+            _terminal.WindowMinimized -= OnTerminalWindowMinimized;
+            _terminal.WindowMaximized -= OnTerminalWindowMaximized;
+            _terminal.WindowRestored -= OnTerminalWindowRestored;
+            _terminal.WindowRaised -= OnTerminalWindowRaised;
+            _terminal.WindowLowered -= OnTerminalWindowLowered;
+            _terminal.WindowFullscreened -= OnTerminalWindowFullscreened;
+            _terminal.BellRang -= OnTerminalBellRang;
+            _terminal.DirectoryChanged -= OnTerminalDirectoryChanged;
+            _terminal.WindowInfoRequested -= OnTerminalWindowInfoRequested;
+
+            _terminal.DataReceived += OnTerminalDataReceived;
+            _terminal.BufferChanged += OnTerminalBufferChanged;
+            _terminal.CursorStyleChanged += OnTerminalCursorStyleChanged;
+            _terminal.TitleChanged += OnTerminalTitleChanged;
+            _terminal.WindowMoved += OnTerminalWindowMoved;
+            _terminal.WindowResized += OnTerminalWindowResized;
+            _terminal.WindowMinimized += OnTerminalWindowMinimized;
+            _terminal.WindowMaximized += OnTerminalWindowMaximized;
+            _terminal.WindowRestored += OnTerminalWindowRestored;
+            _terminal.WindowRaised += OnTerminalWindowRaised;
+            _terminal.WindowLowered += OnTerminalWindowLowered;
+            _terminal.WindowFullscreened += OnTerminalWindowFullscreened;
+            _terminal.BellRang += OnTerminalBellRang;
+            _terminal.DirectoryChanged += OnTerminalDirectoryChanged;
+            _terminal.WindowInfoRequested += OnTerminalWindowInfoRequested;
         }
 
         private void OnCursorBlinkTick(object? sender, EventArgs e)
@@ -1112,11 +1197,22 @@ namespace Iciclecreek.Terminal
                         _ => XT.Selection.SelectionMode.Normal
                     };
 
-                    // Start selection - use viewport-relative row
-                    int viewportRow = row;
-                    _terminal.Selection.StartSelection(col, viewportRow, mode);
-                    _isSelecting = true;
-                    this.RequestInvalidate();
+                    if (mode == XT.Selection.SelectionMode.Normal && !ShowCaretOnClick)
+                    {
+                        // Defer single-click selection until the pointer actually moves;
+                        // this avoids showing a single-cell caret on every click.
+                        _pendingSelectionStart = (col, row);
+                        _isSelecting = true;
+                    }
+                    else
+                    {
+                        // Word / line select, or ShowCaretOnClick=true — start immediately.
+                        int viewportRow = row;
+                        _terminal.Selection.StartSelection(col, viewportRow, mode);
+                        _isSelecting = true;
+                        _pendingSelectionStart = null;
+                        this.RequestInvalidate();
+                    }
                     e.Handled = true;
                     return;
                 }
@@ -1149,7 +1245,16 @@ namespace Iciclecreek.Terminal
                 // If we were selecting, end selection
                 if (_isSelecting)
                 {
-                    _terminal.Selection.EndSelection();
+                    if (_pendingSelectionStart.HasValue)
+                    {
+                        // Pointer was never moved after the click — no visible selection was started,
+                        // so just clear the pending state without leaving any caret.
+                        _pendingSelectionStart = null;
+                    }
+                    else
+                    {
+                        _terminal.Selection.EndSelection();
+                    }
                     _isSelecting = false;
                     e.Handled = true;
                     return;
@@ -1192,6 +1297,12 @@ namespace Iciclecreek.Terminal
                 if (_isSelecting)
                 {
                     int viewportRow = row;
+                    if (_pendingSelectionStart.HasValue)
+                    {
+                        // First movement after a single click — now actually start the selection.
+                        _terminal.Selection.StartSelection(_pendingSelectionStart.Value.Col, _pendingSelectionStart.Value.Row, XT.Selection.SelectionMode.Normal);
+                        _pendingSelectionStart = null;
+                    }
                     _terminal.Selection.UpdateSelection(col, viewportRow);
                     this.RequestInvalidate();
                     e.Handled = true;


### PR DESCRIPTION
## Problem

`TerminalView.OnDetachedFromLogicalTree` unconditionally calls `CleanupProcess()`,
which kills the PTY process and nulls `_ptyConnection`. This makes it impossible
to re-parent the control between two windows (e.g. docking/undocking a terminal
tab into a floating window) without destroying the running session.

Additionally, a single left-click immediately called `StartSelection()`, producing
a visible one-cell blue highlight ("caret") on every click even with no drag, a bit
 inconsistent with most terminal emulators.

## Changes

**TerminalView.cs**
- Added `private bool _suppressCleanupOnDetach` field
- Added `BeginReparent()` / `EndReparent()` public methods to set/clear the flag
- `OnDetachedFromLogicalTree`: skips `CleanupProcess()` when flag is set, but
  still unsubscribes all `_terminal` event handlers as normal
- Added `OnAttachedToLogicalTree` override: re-subscribes `_terminal` events
  after re-attachment to restore rendering, title updates, bell, etc.
  Includes a null guard for the initial attach (before `OnInitialized`).
- Added `ShowCaretOnClick` styled property (default: `false`). When `false`,
  single left-click selection start is deferred until the pointer actually moves,
  so plain clicks produce no visible selection artifact. Double/triple click
  (word/line selection) are unaffected. Set to `true` to restore the previous
  behaviour.

**TerminalControl.cs**
- `BeginReparent()` / `EndReparent()` forwarded to the inner `TerminalView`
- `ShowCaretOnClick` property forwarded to the inner `TerminalView`

## Usage

```csharp
// Re-parenting between windows:
terminalControl.BeginReparent();
oldParent.Content = null;
newParent.Content = terminalControl;
Dispatcher.UIThread.Post(() => terminalControl.EndReparent(), DispatcherPriority.Loaded);

// Opt back into the old single-click caret behaviour:
terminalControl.ShowCaretOnClick = true;
```