### PR TITLE
Raise ProcessExited event in the EOF fallback just like OnPtyProcessExited does.

### DIFF
--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -1920,6 +1920,11 @@ namespace Iciclecreek.Terminal
                             }
 
                             this.RequestInvalidate();
+                            
+                            await Dispatcher.UIThread.InvokeAsync(() =>
+                            {
+                                ProcessExited?.Invoke(this, new ProcessExitedEventArgs(exitCode));
+                            });
                         }
                         break;
                     }


### PR DESCRIPTION
A small fix to ensure that TerminalView.ProcessExited is also raised in the EOF fallback case.