### PR TITLE
Add macOS Cmd+C/Cmd+V clipboard shortcuts and fix selection clearing

### DIFF
--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -903,6 +903,23 @@ namespace Iciclecreek.Terminal
             }
         }
 
+        // macOS uses the Command (⌘ / Meta) key for clipboard shortcuts, following native
+        // platform conventions (Terminal.app, iTerm2, etc.). Windows and Linux terminals use
+        // Ctrl+Shift+C / Ctrl+Shift+V instead, because plain Ctrl+C is reserved for SIGINT.
+        private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+        // True when the key is a modifier pressed on its own (no associated character),
+        // e.g. the ⌘/Ctrl/Shift/Alt keys. Used so a bare modifier press doesn't clear
+        // an active selection before the rest of a copy shortcut is typed.
+        private static bool IsModifierKey(Key key) => key switch
+        {
+            Key.LeftShift or Key.RightShift or
+            Key.LeftCtrl or Key.RightCtrl or
+            Key.LeftAlt or Key.RightAlt or
+            Key.LWin or Key.RWin => true,
+            _ => false,
+        };
+
         protected override async void OnKeyDown(KeyEventArgs e)
         {
             // Only process input if this terminal has focus
@@ -928,7 +945,8 @@ namespace Iciclecreek.Terminal
             {
                 bool isCopy = e.Key == Key.C &&
                               (e.KeyModifiers == KeyModifiers.Control ||
-                               e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift));
+                               e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift) ||
+                               (IsMacOS && e.KeyModifiers == KeyModifiers.Meta));
                 if (isCopy && _terminal.Selection.HasSelection)
                 {
                     e.Handled = true;
@@ -945,6 +963,34 @@ namespace Iciclecreek.Terminal
 
             try
             {
+                // macOS clipboard shortcuts use the Command (Meta) key. These don't collide
+                // with terminal control codes (SIGINT is Ctrl+C, not Cmd+C), so we can handle
+                // them directly here. On Windows/Linux this block is skipped and the
+                // Ctrl / Ctrl+Shift shortcuts below are used instead.
+                if (IsMacOS && e.KeyModifiers == KeyModifiers.Meta)
+                {
+                    // Cmd+C - copy the selection (no-op when nothing is selected, matching macOS)
+                    if (e.Key == Key.C)
+                    {
+                        e.Handled = true;
+                        if (_terminal.Selection.HasSelection)
+                        {
+                            await CopyAsync();
+                            _terminal.Selection.ClearSelection();
+                            this.RequestInvalidate();
+                        }
+                        return;
+                    }
+
+                    // Cmd+V - paste from the clipboard
+                    if (e.Key == Key.V)
+                    {
+                        e.Handled = true;
+                        await PasteAsync();
+                        return;
+                    }
+                }
+
                 // Handle Ctrl+C - copy if there's a selection, otherwise send SIGINT
                 if (e.Key == Key.C && e.KeyModifiers == KeyModifiers.Control)
                 {
@@ -972,8 +1018,11 @@ namespace Iciclecreek.Terminal
                     }
                 }
 
-                // Clear selection for any other keystroke
-                if (_terminal.Selection.HasSelection)
+                // Clear selection for any other keystroke - but ignore bare modifier
+                // presses. Pressing ⌘/Ctrl/Shift on its own fires a KeyDown before the
+                // shortcut's letter arrives; clearing here would lose the selection
+                // before Cmd+C / Ctrl+Shift+C could copy it.
+                if (_terminal.Selection.HasSelection && !IsModifierKey(e.Key))
                 {
                     _terminal.Selection.ClearSelection();
                     this.RequestInvalidate();


### PR DESCRIPTION
## Summary

On macOS the standard clipboard shortcut is the Command (Meta) key, but the terminal only recognized Ctrl-based shortcuts. As a result, pressing Cmd+C or Cmd+V in the terminal did nothing useful and inserted a literal "c" or "v" instead of copying or pasting.

This PR adds platform-native clipboard support for macOS and fixes a related selection bug, while leaving Windows and Linux behavior unchanged.

## Changes

- **Cmd+C / Cmd+V on macOS:** `OnKeyDown` now handles the Command (Meta) key so Cmd+C copies the current selection and Cmd+V pastes from the clipboard, matching native conventions (Terminal.app, iTerm2). This reuses the existing `CopyAsync` / `PasteAsync` methods, so bracketed paste mode and platform line-ending normalization are preserved.
- **Selection no longer cleared by a bare modifier press:** pressing Cmd (or Ctrl/Shift/Alt) on its own fires a KeyDown before the shortcut's letter arrives. The "clear selection for any other keystroke" path was wiping the selection at that point, so by the time Cmd+C arrived there was nothing to copy. A new `IsModifierKey` check skips clearing on bare modifier presses. This also hardens Ctrl+Shift+C on Windows/Linux against the same race.

## Platform behavior

| Action | Windows / Linux | macOS |
|--------|-----------------|-------|
| Copy selection | Ctrl+Shift+C (or Ctrl+C when text is selected) | Cmd+C |
| Paste | Ctrl+Shift+V | Cmd+V |

Plain Ctrl+C on Windows/Linux still sends SIGINT when nothing is selected, and plain Ctrl+V is still forwarded to the application. macOS uses the Command key, which does not collide with terminal control codes.

## Testing

Verified manually on macOS in an Avalonia desktop app: selecting text and pressing Cmd+C copies it, Cmd+V pastes it back at the prompt, and the selection is retained when the Command key is pressed. The library builds cleanly for net8.0 and net10.0 with no warnings.