### PR TITLE
Use null-conditional for PTY connection access

### DIFF
--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -535,9 +535,9 @@ namespace Iciclecreek.Terminal
 
         public XTerm.Terminal Terminal => _terminal;
 
-        public void WaitForExit(int ms) => _ptyConnection!.WaitForExit(ms);
+        public void WaitForExit(int ms) => _ptyConnection?.WaitForExit(ms);
 
-        public void Kill() => _ptyConnection!.Kill();
+        public void Kill() => _ptyConnection?.Kill();
 
         /// <summary>
         /// Pastes text from the clipboard into the terminal.
@@ -597,7 +597,7 @@ namespace Iciclecreek.Terminal
         /// <summary>
         /// Gets the exit code of the launched PTY process after it has terminated.
         /// </summary>
-        public int ExitCode => _ptyConnection!.ExitCode;
+        public int ExitCode => _ptyConnection?.ExitCode ?? -1;
 
         /// <summary>
         /// Gets the operating system process identifier of the launched PTY process.


### PR DESCRIPTION
## Summary
- Replace null-forgiving (`!`) with null-conditional (`?.`) operators on `WaitForExit`, `Kill`, and `ExitCode` in `TerminalView`
- Prevents `NullReferenceException` when called before process launch or after cleanup
- `ExitCode` returns `-1` when no PTY connection exists

## Test plan
- [ ] Call `WaitForExit`/`Kill` before `LaunchProcess()` — should no-op instead of throwing
- [ ] Verify `ExitCode` returns -1 when no process has been launched

🤖 Generated with [Claude Code](https://claude.com/claude-code)