### PR TITLE
Add ShellReady event for first PTY output

### DIFF
--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalControl.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalControl.cs
@@ -59,6 +59,8 @@ namespace Iciclecreek.Terminal
                 nameof(Options),
                 defaultValue: null);
 
+        /// <inheritdoc cref="TerminalView.ShellReady"/>
+        public event EventHandler? ShellReady;
         public event EventHandler<ProcessExitedEventArgs>? ProcessExited;
 
         /// <summary>
@@ -282,6 +284,7 @@ namespace Iciclecreek.Terminal
             {
                 _terminalView.PropertyChanged -= OnTerminalViewPropertyChanged;
                 _terminalView.ProcessExited -= OnTerminalViewProcessExited;
+                _terminalView.ShellReady -= OnTerminalViewShellReady;
             }
 
             SetCurrentDirectory(null);
@@ -297,6 +300,7 @@ namespace Iciclecreek.Terminal
                 _terminalView.Options = Options ?? new XTerm.Options.TerminalOptions();
                 _terminalView.PropertyChanged += OnTerminalViewPropertyChanged;
                 _terminalView.ProcessExited += OnTerminalViewProcessExited;
+                _terminalView.ShellReady += OnTerminalViewShellReady;
                 SetCurrentDirectory(_terminalView.CurrentDirectory);
                 // (no window event hooking needed)
             }
@@ -328,6 +332,11 @@ namespace Iciclecreek.Terminal
         private void OnTerminalViewProcessExited(object? sender, ProcessExitedEventArgs e)
         {
             ProcessExited?.Invoke(this, e);
+        }
+
+        private void OnTerminalViewShellReady(object? sender, EventArgs e)
+        {
+            ShellReady?.Invoke(this, EventArgs.Empty);
         }
 
         private void SetCurrentDirectory(string? currentDirectory)

--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -2001,17 +2001,17 @@ namespace Iciclecreek.Terminal
                         _terminal.Write(output);
                     }
 
-                    if (Interlocked.Exchange(ref _shellReadyFired, 1) == 0)
+                    Dispatcher.UIThread.Post(() =>
                     {
-                        Dispatcher.UIThread.Post(() =>
-                        {
-                            // Ignore queued callbacks from a previous process after LaunchProcess() resets state.
-                            if (_processCts?.Token != cancellationToken)
-                                return;
+                        // Ignore queued callbacks from a previous process after LaunchProcess() resets state.
+                        if (_processCts?.Token != cancellationToken)
+                            return;
 
+                        if (Interlocked.Exchange(ref _shellReadyFired, 1) == 0)
+                        {
                             ShellReady?.Invoke(this, EventArgs.Empty);
-                        });
-                    }
+                        }
+                    });
 
                     // Auto-scroll to bottom when new content arrives, but only in normal buffer.
                     // Alternate buffer (used by full-screen apps like vim, htop, asciiquarium)

--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -55,6 +55,9 @@ namespace Iciclecreek.Terminal
         // IME (Input Method Editor) support
         private TerminalInputMethodClient? _inputMethodClient;
 
+        // Fires ShellReady exactly once after the first PTY output chunk.
+        private int _shellReadyFired; // 0=not yet, 1=fired
+
         // Unique identifier for this terminal instance (for debugging)
         private readonly Guid _instanceId = Guid.NewGuid();
 
@@ -319,6 +322,12 @@ namespace Iciclecreek.Terminal
             target.RemoveHandler(WindowInfoRequestedEvent, handler);
 
         #endregion
+
+        /// <summary>
+        /// Event raised once when the shell produces its first output (e.g. the prompt),
+        /// indicating it is ready to accept input.
+        /// </summary>
+        public event EventHandler? ShellReady;
 
         /// <summary>
         /// Event raised when the PTY process exits.
@@ -1839,6 +1848,7 @@ namespace Iciclecreek.Terminal
             {
                 _processCts = new CancellationTokenSource();
                 Interlocked.Exchange(ref _processExitHandled, 0);  // Reset flag for new process
+                Interlocked.Exchange(ref _shellReadyFired, 0);
 
                 // Determine the process to launch based on OS if not explicitly set
                 string processToLaunch = Process;
@@ -1936,6 +1946,9 @@ namespace Iciclecreek.Terminal
                     {
                         _terminal.Write(output);
                     }
+
+                    if (Interlocked.Exchange(ref _shellReadyFired, 1) == 0)
+                        Dispatcher.UIThread.Post(() => ShellReady?.Invoke(this, EventArgs.Empty));
 
                     // Auto-scroll to bottom when new content arrives, but only in normal buffer.
                     // Alternate buffer (used by full-screen apps like vim, htop, asciiquarium)

--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -2002,7 +2002,16 @@ namespace Iciclecreek.Terminal
                     }
 
                     if (Interlocked.Exchange(ref _shellReadyFired, 1) == 0)
-                        Dispatcher.UIThread.Post(() => ShellReady?.Invoke(this, EventArgs.Empty));
+                    {
+                        Dispatcher.UIThread.Post(() =>
+                        {
+                            // Ignore queued callbacks from a previous process after LaunchProcess() resets state.
+                            if (_processCts?.Token != cancellationToken)
+                                return;
+
+                            ShellReady?.Invoke(this, EventArgs.Empty);
+                        });
+                    }
 
                     // Auto-scroll to bottom when new content arrives, but only in normal buffer.
                     // Alternate buffer (used by full-screen apps like vim, htop, asciiquarium)


### PR DESCRIPTION
## Summary
- Add `ShellReady` event to `TerminalView` and `TerminalControl`, fired once when the shell produces its first output (e.g. the prompt)
- Uses `Interlocked` for thread-safe one-shot firing, dispatched to UI thread
- Reset on each `LaunchProcess()` call

## Test plan
- [ ] Subscribe to `ShellReady` and verify it fires once after shell startup
- [ ] Verify it does not fire again on subsequent output
- [ ] Verify it resets and fires again after calling `LaunchProcess()` a second time

🤖 Generated with [Claude Code](https://claude.com/claude-code)