### PR TITLE
Add OutputReceived event for PTY output monitoring

### DIFF
--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalControl.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalControl.cs
@@ -60,6 +60,8 @@ namespace Iciclecreek.Terminal
                 defaultValue: null);
 
         public event EventHandler<ProcessExitedEventArgs>? ProcessExited;
+        /// <inheritdoc cref="TerminalView.OutputReceived"/>
+        public event EventHandler<string>? OutputReceived;
 
         /// <summary>
         /// Gets or sets the brush used to render selected terminal text.
@@ -282,6 +284,7 @@ namespace Iciclecreek.Terminal
             {
                 _terminalView.PropertyChanged -= OnTerminalViewPropertyChanged;
                 _terminalView.ProcessExited -= OnTerminalViewProcessExited;
+                _terminalView.OutputReceived -= OnTerminalViewOutputReceived;
             }
 
             SetCurrentDirectory(null);
@@ -297,6 +300,7 @@ namespace Iciclecreek.Terminal
                 _terminalView.Options = Options ?? new XTerm.Options.TerminalOptions();
                 _terminalView.PropertyChanged += OnTerminalViewPropertyChanged;
                 _terminalView.ProcessExited += OnTerminalViewProcessExited;
+                _terminalView.OutputReceived += OnTerminalViewOutputReceived;
                 SetCurrentDirectory(_terminalView.CurrentDirectory);
                 // (no window event hooking needed)
             }
@@ -328,6 +332,11 @@ namespace Iciclecreek.Terminal
         private void OnTerminalViewProcessExited(object? sender, ProcessExitedEventArgs e)
         {
             ProcessExited?.Invoke(this, e);
+        }
+
+        private void OnTerminalViewOutputReceived(object? sender, string e)
+        {
+            OutputReceived?.Invoke(this, e);
         }
 
         private void SetCurrentDirectory(string? currentDirectory)

--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -34,6 +34,7 @@ namespace Iciclecreek.Terminal
         private double _charHeight;
         private int _bufferSize = 1000;
         private bool _isAlternateBuffer;
+        private volatile bool _userScrolledUp;
 
         // Process management
         private IPtyConnection? _ptyConnection;
@@ -326,6 +327,11 @@ namespace Iciclecreek.Terminal
         public event EventHandler<ProcessExitedEventArgs>? ProcessExited;
 
         /// <summary>
+        /// Event raised when the terminal receives output from the PTY process.
+        /// </summary>
+        public event EventHandler<string>? OutputReceived;
+
+        /// <summary>
         /// Event raised when the terminal title changes.
         /// </summary>
         public event EventHandler<TitleChangedEventArgs>? TitleChanged;
@@ -509,6 +515,7 @@ namespace Iciclecreek.Terminal
 
                 if (oldValue != _terminal.Buffer.ViewportY)
                 {
+                    _userScrolledUp = _terminal.Buffer.ViewportY < MaxScrollback;
                     RaisePropertyChanged(ViewportYProperty, oldValue, _terminal.Buffer.ViewportY);
                     this.RequestInvalidate();
                 }
@@ -1925,6 +1932,8 @@ namespace Iciclecreek.Terminal
                     }
 
                     var output = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+
+                    Dispatcher.UIThread.Post(() => OutputReceived?.Invoke(this, output));
 
                     // Snapshot before write so we can detect buffer growth (MaxScrollback
                     // increases when _terminal.Write adds lines; ScrollToBottom only moves


### PR DESCRIPTION
## Summary
- Add `OutputReceived` event to `TerminalView` and `TerminalControl`
- Fires on UI thread each time the terminal receives raw output from the PTY process
- Enables consumers to monitor, log, or process terminal output

## Test plan
- [ ] Subscribe to `OutputReceived` and verify it fires with each PTY output chunk
- [ ] Verify the event fires on the UI thread (safe for UI updates)
- [ ] Run a command that produces large output and verify no events are lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)