### PR TITLE
Add URL hover detection and Ctrl+Click support

### DIFF
--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalControl.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalControl.cs
@@ -59,7 +59,10 @@ namespace Iciclecreek.Terminal
                 nameof(Options),
                 defaultValue: null);
 
+        public event EventHandler? ShellReady;
         public event EventHandler<ProcessExitedEventArgs>? ProcessExited;
+        /// <inheritdoc cref="TerminalView.UrlClicked"/>
+        public event EventHandler<UrlClickedEventArgs>? UrlClicked;
 
         /// <summary>
         /// Gets or sets the brush used to render selected terminal text.
@@ -282,6 +285,7 @@ namespace Iciclecreek.Terminal
             {
                 _terminalView.PropertyChanged -= OnTerminalViewPropertyChanged;
                 _terminalView.ProcessExited -= OnTerminalViewProcessExited;
+                _terminalView.UrlClicked -= OnTerminalViewUrlClicked;
             }
 
             SetCurrentDirectory(null);
@@ -297,6 +301,7 @@ namespace Iciclecreek.Terminal
                 _terminalView.Options = Options ?? new XTerm.Options.TerminalOptions();
                 _terminalView.PropertyChanged += OnTerminalViewPropertyChanged;
                 _terminalView.ProcessExited += OnTerminalViewProcessExited;
+                _terminalView.UrlClicked += OnTerminalViewUrlClicked;
                 SetCurrentDirectory(_terminalView.CurrentDirectory);
                 // (no window event hooking needed)
             }
@@ -328,6 +333,11 @@ namespace Iciclecreek.Terminal
         private void OnTerminalViewProcessExited(object? sender, ProcessExitedEventArgs e)
         {
             ProcessExited?.Invoke(this, e);
+        }
+
+        private void OnTerminalViewUrlClicked(object? sender, UrlClickedEventArgs e)
+        {
+            UrlClicked?.Invoke(this, e);
         }
 
         private void SetCurrentDirectory(string? currentDirectory)

--- a/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/TerminalView.cs
@@ -16,6 +16,7 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using XTerm.Buffer;
@@ -35,11 +36,17 @@ namespace Iciclecreek.Terminal
         private int _bufferSize = 1000;
         private bool _isAlternateBuffer;
 
+        // URL hover state
+        private static readonly Regex UrlRegex = new(@"https?://[^\s<>""'`\]\)\},;]+", RegexOptions.Compiled);
+        private (string Url, int BufferLine, int StartCol, int EndCol)? _hoveredLink;
+        private Cursor? _savedCursor;
+
         // Process management
         private IPtyConnection? _ptyConnection;
         private CancellationTokenSource? _processCts;
         private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         private int _processExitHandled;    // 0=false, 1=true — written via Interlocked
+        private int _shellReadyFired;       // 0=false, 1=true — written via Interlocked
         private readonly object _terminalLock = new object(); // Serialises all _terminal.Write/WriteLine calls
 
         // Cursor blinking
@@ -324,6 +331,17 @@ namespace Iciclecreek.Terminal
         /// Event raised when the PTY process exits.
         /// </summary>
         public event EventHandler<ProcessExitedEventArgs>? ProcessExited;
+
+        /// <summary>
+        /// Event raised once when the shell produces its first output (e.g. the prompt),
+        /// indicating it is ready to accept input.
+        /// </summary>
+        public event EventHandler? ShellReady;
+
+        /// <summary>
+        /// Event raised when a URL in the terminal is Ctrl+Clicked.
+        /// </summary>
+        public event EventHandler<UrlClickedEventArgs>? UrlClicked;
 
         /// <summary>
         /// Event raised when the terminal title changes.
@@ -1158,6 +1176,18 @@ namespace Iciclecreek.Terminal
                 var col = (int)(point.X / _charWidth);
                 var row = (int)(point.Y / _charHeight);
 
+                // Ctrl+Click on a hovered URL
+                if (_hoveredLink.HasValue && e.KeyModifiers.HasFlag(KeyModifiers.Control))
+                {
+                    var leftBtn = e.GetCurrentPoint(this).Properties.IsLeftButtonPressed;
+                    if (leftBtn)
+                    {
+                        UrlClicked?.Invoke(this, new UrlClickedEventArgs(_hoveredLink.Value.Url));
+                        e.Handled = true;
+                        return;
+                    }
+                }
+
                 // Check if we should handle selection (app doesn't want mouse, or Shift override)
                 if (ShouldHandleSelection(e.KeyModifiers))
                 {
@@ -1308,6 +1338,10 @@ namespace Iciclecreek.Terminal
                     return;
                 }
 
+                // URL hover detection
+                int bufferLine = _terminal.Buffer.ViewportY + row;
+                UpdateHoveredUrl(bufferLine, col);
+
                 // Forward mouse event to application
                 if (_ptyConnection == null)
                     return;
@@ -1329,6 +1363,12 @@ namespace Iciclecreek.Terminal
             {
                 Debug.WriteLine($"Error handling mouse move: {ex.Message}");
             }
+        }
+
+        protected override void OnPointerExited(PointerEventArgs e)
+        {
+            base.OnPointerExited(e);
+            ClearHoveredUrl();
         }
 
         protected override async void OnPointerWheelChanged(PointerWheelEventArgs e)
@@ -1734,6 +1774,77 @@ namespace Iciclecreek.Terminal
             return !appWantsMouse || shiftHeld;
         }
 
+        private string GetLineText(BufferLine line, int cols)
+        {
+            var sb = new StringBuilder(cols);
+            for (int x = 0; x < cols && x < line.Length; x++)
+            {
+                var cell = line[x];
+                if (cell.Width == 0) continue;
+                sb.Append(cell.Content ?? " ");
+            }
+            return sb.ToString();
+        }
+
+        private (string Url, int StartCol, int EndCol)? FindUrlAtColumn(int bufferLine, int col)
+        {
+            if (bufferLine < 0 || bufferLine >= _terminal.Buffer.Length)
+                return null;
+
+            var line = _terminal.Buffer.GetLine(bufferLine);
+            if (line == null) return null;
+
+            var text = GetLineText(line, _terminal.Cols);
+            foreach (Match m in UrlRegex.Matches(text))
+            {
+                if (col >= m.Index && col < m.Index + m.Length)
+                    return (m.Value, m.Index, m.Index + m.Length - 1);
+            }
+            return null;
+        }
+
+        private void UpdateHoveredUrl(int bufferLine, int col)
+        {
+            var found = FindUrlAtColumn(bufferLine, col);
+
+            if (found.HasValue)
+            {
+                var newHover = (found.Value.Url, bufferLine, found.Value.StartCol, found.Value.EndCol);
+                if (_hoveredLink.HasValue && _hoveredLink.Value == newHover)
+                    return;
+
+                ClearHoveredUrl();
+                _hoveredLink = newHover;
+                _savedCursor = Cursor;
+                Cursor = new Cursor(StandardCursorType.Hand);
+                InvalidateUrlLine(bufferLine);
+            }
+            else
+            {
+                ClearHoveredUrl();
+            }
+        }
+
+        private void ClearHoveredUrl()
+        {
+            if (!_hoveredLink.HasValue) return;
+            var oldLine = _hoveredLink.Value.BufferLine;
+            _hoveredLink = null;
+            if (_savedCursor != null)
+            {
+                Cursor = _savedCursor;
+                _savedCursor = null;
+            }
+            InvalidateUrlLine(oldLine);
+        }
+
+        private void InvalidateUrlLine(int bufferLine)
+        {
+            var line = _terminal.Buffer.GetLine(bufferLine);
+            if (line != null) line.Cache = null;
+            this.RequestInvalidate();
+        }
+
         private bool TryGetPrintableChar(KeyEventArgs e, out char character)
         {
             // Prefer the symbol provided by Avalonia (already respects layout)
@@ -1937,6 +2048,9 @@ namespace Iciclecreek.Terminal
                         _terminal.Write(output);
                     }
 
+                    if (Interlocked.Exchange(ref _shellReadyFired, 1) == 0)
+                        Dispatcher.UIThread.Post(() => ShellReady?.Invoke(this, EventArgs.Empty));
+
                     // Auto-scroll to bottom when new content arrives, but only in normal buffer.
                     // Alternate buffer (used by full-screen apps like vim, htop, asciiquarium)
                     // handles its own cursor positioning and shouldn't be scrolled.
@@ -2119,6 +2233,9 @@ namespace Iciclecreek.Terminal
                     }
                 }
 
+                // Render URL underline when hovering
+                RenderHoveredUrl(context, viewportY, scale);
+
                 // Render selection overlay
                 RenderSelection(context, viewportY, scale);
 
@@ -2235,6 +2352,22 @@ namespace Iciclecreek.Terminal
             // Cache the text runs (but not when ReverseVideo mode is active)
             if (!_terminal.ReverseVideo)
                 line.Cache = textRuns;
+        }
+
+        private void RenderHoveredUrl(DrawingContext context, int viewportY, double scale)
+        {
+            if (!_hoveredLink.HasValue) return;
+
+            var link = _hoveredLink.Value;
+            int screenRow = link.BufferLine - viewportY;
+            if (screenRow < 0 || screenRow >= _terminal.Rows) return;
+
+            var startX = Snap(link.StartCol * _charWidth, scale);
+            var endX = Snap((link.EndCol + 1) * _charWidth, scale);
+            var y = Snap((screenRow + 1) * _charHeight - 1, scale);
+
+            var pen = new Pen(Foreground, 1);
+            context.DrawLine(pen, new Point(startX, y), new Point(endX, y));
         }
 
         /// <summary>

--- a/src/Iciclecreek.Avalonia.TerminalWindow/UrlClickedEventArgs.cs
+++ b/src/Iciclecreek.Avalonia.TerminalWindow/UrlClickedEventArgs.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Iciclecreek.Terminal
+{
+    public class UrlClickedEventArgs : EventArgs
+    {
+        public string Url { get; }
+
+        public UrlClickedEventArgs(string url)
+        {
+            Url = url;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Detect URLs (http/https) in terminal output and highlight them on hover with underline + hand cursor
- Ctrl+Click on a hovered URL fires the `UrlClicked` event (consumer decides how to open)
- New `UrlClickedEventArgs` class with the clicked URL
- Visual underline rendered in the drawing pass, cursor restores on mouse exit

## Test plan
- [ ] Hover over a URL in terminal output — verify underline appears and cursor changes to hand
- [ ] Move cursor away — verify underline disappears and cursor restores
- [ ] Ctrl+Click a URL — verify `UrlClicked` event fires with correct URL
- [ ] Click without Ctrl — verify normal selection behavior is preserved
- [ ] Test with URLs containing query params, paths, and fragments

🤖 Generated with [Claude Code](https://claude.com/claude-code)